### PR TITLE
Update

### DIFF
--- a/app.html
+++ b/app.html
@@ -253,6 +253,7 @@
         if(localStorage.getItem('discordRPC')) {
             ipcRenderer.send('toggleRpc', '');
             discordRpc(true);
+            iframe.notify('La Rich Presence Discord est automatiquement activée au démarrage. Pour la désactiver maintiens : CTRL + ALT + D.');
         }
     });
 

--- a/app.js
+++ b/app.js
@@ -239,6 +239,7 @@ try {
     });
     app.on('ready', async () => {
         await globalShortcut.register('CommandOrControl+Alt+D', () => sendWindow('shortcutDiscord', ''));
+        await globalShortcut.register('F11', () => mainWindow.isFullScreen() ? mainWindow.setFullScreen(false) : mainWindow.setFullScreen(true));
         await createWindow();
         await autoUpdater.checkForUpdatesAndNotify();
     });

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "uninstallerIcon": "icon.ico",
       "uninstallDisplayName": "HabboCity",
       "oneClick": false,
-      "perMachine": true,
+      "perMachine": false,
       "allowToChangeInstallationDirectory": false,
       "artifactName": "City-${version}.${ext}",
       "include": "build/installer.nsh"


### PR DESCRIPTION
- "perMachine" : false ; Évite de devoir obligatoirement exécuter l'installeur avec les privilèges administrateur ;
- Ajout du raccourci clavier "F11" pour mettre en plein écran ;
- Ajout d'un avertissement lorsque la Rich Presence Discord est activée au démarrage.